### PR TITLE
Added unit conversion deg to rad to be consistent with documentation

### DIFF
--- a/adafruit_fxas21002c.py
+++ b/adafruit_fxas21002c.py
@@ -84,6 +84,9 @@ GYRO_RANGE_500DPS = 500
 GYRO_RANGE_1000DPS = 1000
 GYRO_RANGE_2000DPS = 2000
 
+# Unit conversion:
+DEGREE_TO_RAD = 3.141592653589793 / 180
+
 
 class FXAS21002C:
     """Driver for the NXP FXAS21002C gyroscope."""
@@ -172,4 +175,5 @@ class FXAS21002C:
             factor = _GYRO_SENSITIVITY_1000DPS
         elif self._gyro_range == GYRO_RANGE_2000DPS:
             factor = _GYRO_SENSITIVITY_2000DPS
+        factor *= DEGREE_TO_RAD
         return [x * factor for x in raw]


### PR DESCRIPTION
Issue described in #18
All the findable documentation says `gyroscope` returns in units of rad/s, but actually returns values in deg/s.

This pull request changes the driver to match the documentation 